### PR TITLE
tx->submit args

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -37,24 +37,34 @@ L<Mojo::Transaction::HTTP>.
 
 =head1 METHODS
 
-L<Mojo::Transaction::HTTP::Role::Mechanize> implements the following methods.
+L<Mojo::Transaction::HTTP::Role::Mechanize> implements the following method.
 
 =head2 submit
 
-  # result
+  # result using selector
   $submit_tx = $tx->submit('#id', username => 'fry');
+  # result without selector using default submission
+  $submit_tx = $tx->submit(username => 'fry');
+  # passing hash, rather than list, of values
+  $submit_tx = $tx->submit({username => 'fry'});
+  # passing hash, rather than list, of values and a selector
+  $submit_tx = $tx->submit('#id', {username => 'fry'});
 
 Build a new L<Mojo::Transaction::HTTP> object with
 L<Mojo::UserAgent::Transactor/"tx"> and the contents of the C<form> with the
-C<$id> and merged values.
+C<$id> and merged values.  If no selector is given, the first non-disabled
+button or appropriate input element (of type button, submit, or image)
+will be used for the submission.
 
 =head1 AUTHOR
 
-kiwiroy - Roy Storey <kiwiroy@cpan.org>
+kiwiroy - Roy Storey C<kiwiroy@cpan.org>
 
 =head1 CONTRIBUTORS
 
-tekki - Rolf Stöckli <tekki@cpan.org>
+tekki - Rolf Stöckli C<tekki@cpan.org>
+
+lindleyw - William Lindley C<wlindley+remove+this@wlindley.com>
 
 =head1 LICENSE
 

--- a/lib/Mojo/Transaction/HTTP/Role/Mechanize.pm
+++ b/lib/Mojo/Transaction/HTTP/Role/Mechanize.pm
@@ -8,19 +8,20 @@ our $VERSION = '0.03';
 requires qw{error};
 
 sub submit {
-  my $any = 'button:not([disabled]), input:matches([type=button],'
-	    . ' [type=submit], [type=image]):not([disabled])';
-  my ($self, $selector, $overlay) = (shift, (@_ % 2 ? shift : $any, {@_}));
+  my ($self, $selector, $overlay) = (shift);
+  $overlay   = pop if @_ && ref($_[-1]) eq 'HASH';
+  $selector  = shift if @_ % 2;
+  $overlay ||= { @_ };
   # cannot continue from error state
   return if $self->error;
   # form from selector
   return unless defined(my $form = $self->res->dom->find('form')
-    ->grep(sub { $_->at($selector) })->first);
+    ->grep(sub { $_->at($selector || '') })->first);
   # compose ...
   $form->with_roles('Mojo::DOM::Role::Form')
     unless Role::Tiny::does_role($form, 'Mojo::DOM::Role::Form');
-  # now there is a form, rely on _form_default_submit() if we relied on $any b4.
-  $selector = undef if $any eq $selector;
+  # # now there is a form, rely on _form_default_submit() if we relied on $any b4.
+  # $selector = undef if $any eq $selector;
   return unless (my ($method, $target, $type) =
     $form->target($selector));
   $target = $self->req->url->new($target);
@@ -89,6 +90,8 @@ L<Mojo::Transaction::HTTP::Role::Mechanize> implements the following method.
   $submit_tx = $tx->submit(username => 'fry');
   # passing hash, rather than list, of values
   $submit_tx = $tx->submit({username => 'fry'});
+  # passing hash, rather than list, of values and a selector
+  $submit_tx = $tx->submit('#id', {username => 'fry'});
 
 Build a new L<Mojo::Transaction::HTTP> object with
 L<Mojo::UserAgent::Transactor/"tx"> and the contents of the C<form> with the
@@ -98,11 +101,13 @@ will be used for the submission.
 
 =head1 AUTHOR
 
-kiwiroy - Roy Storey <kiwiroy@cpan.org>
+kiwiroy - Roy Storey C<kiwiroy@cpan.org>
 
 =head1 CONTRIBUTORS
 
-tekki - Rolf Stöckli <tekki@cpan.org>
+tekki - Rolf Stöckli C<tekki@cpan.org>
+
+lindleyw - William Lindley C<wlindley+remove+this@wlindley.com>
 
 =head1 LICENSE
 

--- a/lib/Mojo/Transaction/HTTP/Role/Mechanize.pm
+++ b/lib/Mojo/Transaction/HTTP/Role/Mechanize.pm
@@ -79,16 +79,22 @@ L<Mojo::Transaction::HTTP>.
 
 =head1 METHODS
 
-L<Mojo::Transaction::HTTP::Role::Mechanize> implements the following methods.
+L<Mojo::Transaction::HTTP::Role::Mechanize> implements the following method.
 
 =head2 submit
 
-  # result
+  # result using selector
   $submit_tx = $tx->submit('#id', username => 'fry');
+  # result without selector using default submission
+  $submit_tx = $tx->submit(username => 'fry');
+  # passing hash, rather than list, of values
+  $submit_tx = $tx->submit({username => 'fry'});
 
 Build a new L<Mojo::Transaction::HTTP> object with
 L<Mojo::UserAgent::Transactor/"tx"> and the contents of the C<form> with the
-C<$id> and merged values.
+C<$id> and merged values.  If no selector is given, the first non-disabled
+button or appropriate input element (of type button, submit, or image)
+will be used for the submission.
 
 =head1 AUTHOR
 

--- a/t/mechanize.t
+++ b/t/mechanize.t
@@ -64,8 +64,19 @@ $ua->start($submit_tx);
 is_deeply $submit_tx->res->json, {%exp, a => 'Z', p => ['P0', 'P1']},
   'expected response - foo not included';
 
+$submit_tx = $tx->submit('#submit-form-1', {a => 'Z', o => 'L', foo => 'bar'});
+$ua->start($submit_tx);
+is_deeply $submit_tx->res->json, {%exp, a => 'Z', p => ['P0', 'P1']},
+  'expected response - foo not included';
+
 $exp{o} = 'O'; # add back - this is the default button
 $submit_tx = $tx->submit(a => 'X', 'm' => 'on');
+ok $submit_tx;
+$ua->start($submit_tx);
+is_deeply $submit_tx->res->json, {%exp, 'a' => 'X', 'm' => 'on'},
+  'expected response';
+
+$submit_tx = $tx->submit({a => 'X', 'm' => 'on'});
 ok $submit_tx;
 $ua->start($submit_tx);
 is_deeply $submit_tx->res->json, {%exp, 'a' => 'X', 'm' => 'on'},


### PR DESCRIPTION
Following on from #5 

Add support for more argument types to `$tx->submit` and change default selector logic. I don't think it supported *enter* as submit forms with no *button*.