### PR TITLE
New method extract_forms

### DIFF
--- a/.perltidyrc
+++ b/.perltidyrc
@@ -1,0 +1,14 @@
+-pbp     # Start with Perl Best Practices
+-w       # Show all warnings
+-iob     # Ignore old breakpoints
+-l=80    # 80 characters per line
+-mbl=2   # No more than 2 blank lines
+-i=2     # Indentation is 2 columns
+-ci=2    # Continuation indentation is 2 columns
+-vt=0    # Less vertical tightness
+-pt=2    # High parenthesis tightness
+-bt=2    # High brace tightness
+-sbt=2   # High square bracket tightness
+-wn      # Weld nested containers
+-isbc    # Don't indent comments without leading space
+-nst     # Don't output to STDOUT

--- a/lib/Mojo/Transaction/HTTP/Role/Mechanize.pm
+++ b/lib/Mojo/Transaction/HTTP/Role/Mechanize.pm
@@ -7,37 +7,45 @@ our $VERSION = '0.05';
 
 requires qw{error};
 
+sub extract_forms {
+  my $self = shift;
+
+  my $forms
+    = $self->res->dom->find('form')->each(sub { $_->with_roles('+Form') });
+
+  return $forms;
+}
+
 sub submit {
   my ($self, $selector, $overlay) = (shift);
-  $overlay   = pop if @_ && ref($_[-1]) eq 'HASH';
-  $selector  = shift if @_ % 2;
-  $overlay ||= { @_ };
+  $overlay  = pop   if @_ && ref($_[-1]) eq 'HASH';
+  $selector = shift if @_ % 2;
+  $overlay ||= {@_};
+
   # cannot continue from error state
   return if $self->error;
-  # form from selector
-  return unless defined(my $form = $self->res->dom->find('form')
-    ->grep(sub { $_->at($selector || '') })->first);
-  # compose ...
-  $form->with_roles('Mojo::DOM::Role::Form')
-    unless Role::Tiny::does_role($form, 'Mojo::DOM::Role::Form');
-  # # now there is a form, rely on _form_default_submit() if we relied on $any b4.
-  # $selector = undef if $any eq $selector;
-  return unless (my ($method, $target, $type) =
-    $form->target($selector));
+
+  # extract form
+  my $form = $self->extract_forms->grep(sub { $_->at($selector // '') })->first
+    or return;
+
+  return unless (my ($method, $target, $type) = $form->target($selector));
   $target = $self->req->url->new($target);
   $target = $target->to_abs($self->req->url) unless $target->is_abs;
+
   # values from form
   my $state = $form->val($selector);
+
   # merge in new values of form elements
   my @keys = grep { exists $overlay->{$_} } keys %$state;
   @$state{@keys} = @$overlay{@keys};
 
   # build a new transaction ...
   return Mojo::UserAgent::Transactor->new->tx(
-    $method => $target, {}, form => $state
-    );
+    $method => $target,
+    {}, form => $state
+  );
 }
-
 
 1;
 
@@ -66,9 +74,19 @@ Mojo::Transaction::HTTP::Role::Mechanize - Mechanize Mojo a little
 
 =head1 SYNOPSIS
 
-  # description
+  use Mojo::UserAgent;
+  use Mojo::Transaction::HTTP::Role::Mechanize;
+
+  my $ua = Mojo::UserAgent->new;
   my $tx = $ua->get('/')->with_roles('+Mechanize');
+
+  # call submit immediately
   my $submit_tx = $tx->submit('#submit-id', username => 'fry');
+  $ua->start($submit_tx);
+
+  # first extract form values
+  my $values = $tx->extract_forms->first->val;
+  $submit_tx = $tx->submit('#submit-id', counter => $values->{counter} + 3);
   $ua->start($submit_tx);
 
 =head1 DESCRIPTION
@@ -80,14 +98,24 @@ L<Mojo::Transaction::HTTP>.
 
 L<Mojo::Transaction::HTTP::Role::Mechanize> implements the following method.
 
+=head2 extract_forms
+
+  $collection = $tx->extract_forms;
+
+Returns a L<Mojo::Collection> of L<Mojo::DOM> elements with activated L<Mojo::DOM::Role::Form>
+that contains all the forms of the page.
+
 =head2 submit
 
   # result using selector
   $submit_tx = $tx->submit('#id', username => 'fry');
+
   # result without selector using default submission
   $submit_tx = $tx->submit(username => 'fry');
+
   # passing hash, rather than list, of values
   $submit_tx = $tx->submit({username => 'fry'});
+
   # passing hash, rather than list, of values and a selector
   $submit_tx = $tx->submit('#id', {username => 'fry'});
 
@@ -111,5 +139,9 @@ lindleyw - William Lindley C<wlindley+remove+this@wlindley.com>
 
 This library is free software and may be distributed under the same terms as
 perl itself.
+
+=head1 SEE ALSO
+
+L<Mojo::DOM::Role::Form>, L<Mojolicious>.
 
 =cut

--- a/t/mechanize.t
+++ b/t/mechanize.t
@@ -32,8 +32,11 @@ get '/metacpan' => sub {
 my $ua = new_ok 'Mojo::UserAgent';
 my $tx = $ua->get('/')->with_roles('+Mechanize');
 ok $tx->does('Mojo::Transaction::HTTP::Role::Mechanize'), 'obj compose';
-my $dom = $tx->result->dom->with_roles('+Form');
-my $form = $dom->at('form');
+
+ok my $forms = $tx->extract_forms, 'extract forms';
+is $forms->size, 1, '1 form extracted';
+my $form = $forms->first;
+ok $form->does('Mojo::DOM::Role::Form'), 'correct role';
 
 my %exp = ( a => 'A', b => 'B', c => 'C', d => 'D', f => ['I', 'J'], m => 'M',
   o => 'O', p => 'P0', r => 'on', t => '',


### PR DESCRIPTION
In `Mechanize.pm` I've moved the code that extracts the forms from the DOM to a new method `extract_forms`. I've tried several variants and for example was not sure for example if this method should have a selector or not.
If we use this module to communicate with legacy applications we can imagine a lot of bad situations, like multiple forms on a page and tags without IDs. Maybe later we will add the possibility to call `$tx->submit($form, '#button')`. But for the moment I think we shouldn't make things too complicated if we have no real use case.
Then I've added `.perltidyrc` from Mojolicious and tidied `Mechanize.pm` with it. Hope this is okay.